### PR TITLE
This fix makes dfm to skip empty lines in .dfminstall.

### DIFF
--- a/bin/dfm
+++ b/bin/dfm
@@ -186,10 +186,12 @@ sub install_files {
         open( my $skip_fh, '<', "$from_dir/.dfminstall" );
         foreach my $line (<$skip_fh>) {
             chomp($line);
-            my ( $filename, $option ) = split( / /, $line );
-            $skip_files->{$filename} = 1;
-            if ( !defined $option || $option ne 'skip' ) {
-                push( @$recurse_files, $filename );
+            if ( length ( $line ) ) {
+                my ( $filename, $option ) = split( / /, $line );
+                $skip_files->{$filename} = 1;
+                if ( !defined $option || $option ne 'skip' ) {
+                    push( @$recurse_files, $filename );
+                }
             }
         }
         close($skip_fh);


### PR DESCRIPTION
Empty lines cause a weird recursion problem if you don't realize you added an empty line to
the file.

I cannot write any Perl, I guess there's a more idiomatic way of writing that.

PS: btw, thanks for this nice piece of software!
