### PR TITLE
Dfm uninitialized warnings due to usage of Cwd::realpath

### DIFF
--- a/bin/dfm
+++ b/bin/dfm
@@ -680,8 +680,8 @@ sub cleanup_dangling_symlinks {
             my $target_base
                 = realpath( File::Spec->rel2abs( File::Spec->catpath( '', @elements ) ) );
 
-            DEBUG("target_base $target_base $source_dir");
-            if ( $target_base eq $source_dir ) {
+            DEBUG("target_base '", defined $target_base ? $target_base : '', "' $source_dir");
+            if ( defined $target_base and $target_base eq $source_dir ) {
                 INFO("  Cleaning up dangling symlink $direntry ($link_target).");
                 unlink($direntry) if !$opts{'dry-run'};
             }


### PR DESCRIPTION
dfm can emit warnings like the following due to Cwd::realpath returning undef on paths containing spaces:

DEBUG: backups points at /my/path/Some Drive/dir
Use of uninitialized value $target_base in concatenation (.) or string at .../dotfiles/bin/dfm line 683.
DEBUG: target_base .../dotfiles
Use of uninitialized value $target_base in string eq at .../dotfiles/bin/dfm line 684.

This fix simply ensures $target_base is defined if we use/print it.
- example of Cwd::realpath returning undef:
  $ perl -wl -MCwd -e 'my $p=Cwd::realpath(shift); print "p($p)";' "/path/has a/space"
  Use of uninitialized value $p in concatenation (.) or string at -e line 1.
  p()
